### PR TITLE
Fix missing callback

### DIFF
--- a/src/snippetjs/widget/snippetjs_datasource.js
+++ b/src/snippetjs/widget/snippetjs_datasource.js
@@ -95,6 +95,7 @@ define([
 
             if (this._init === true && this.refresh === false){
                 logger.debug(this.id + "._loadData: skipping load because the widget refresh setting is set to false.");
+                self._executeCallback(callback, "_loadData");
                 return;
             }
 


### PR DESCRIPTION
Fixes a missing callback. The callback function was never called whenever the widget skipped loading in the _loadData function. Mendix R&D found this issue in one of our tickets. The result of the missing callback resulted in non-responsive pages after a commit and refresh in a nanoflow.

Below is the full scenario (copied from Mendix ticket):

- When user clicks button, nanoflow NB_MobileWorkOrder_Step1_StartJourney is called.
- Change action inside this nanoflow triggers other widgets on the page update according to the new change
- As a part of this update, listView1 in SN_PhoneLayout_CurrentWorkorder reloads.
- Nanoflow waits for listView1 to finish reloading.
- listView1 loads the data and renders the first row which contains javaScriptSnippet_DataSource_1 custom widget.
- But this custom widget does not notify list view that it is loaded.
- Nanoflow does not continue.